### PR TITLE
Modification in Main Action method signature and improved the error log

### DIFF
--- a/rust1.32/src/action_loop/src/main.rs
+++ b/rust1.32/src/action_loop/src/main.rs
@@ -17,6 +17,11 @@ struct Input {
     environment: HashMap<String, Value>,
 }
 
+fn log_error(fd3: &mut File, error: Error) {
+    writeln!(fd3, "{{\"error\":\"{}\"}}\n", error).expect("Error writing on fd3");
+    eprintln!("error: {}", error);
+}
+
 fn main() {
     let mut fd3 = unsafe { File::from_raw_fd(3) };
     let stdin = stdin();
@@ -33,15 +38,15 @@ fn main() {
                         Ok(response) => {
                             writeln!(&mut fd3, "{}", response).expect("Error writing on fd3")
                         }
-                        Err(_) => writeln!(&mut fd3, "{{\"error\":\"Error parsing the action result\"\n}}").expect("Error writing on fd3"),
+                        Err(err) => log_error(&mut fd3, err),
                     },
                     Err(err) => {
-                        eprintln!("Error formatting result value json: {}", err);
+                        log_error(&mut fd3, err);
                     }
                 }
             }
             Err(err) => {
-                eprintln!("Error parsing input: {}", err);
+                log_error(&mut fd3, err);
             }
         }
         stdout().flush().expect("Error flushing stdout");

--- a/rust1.32/src/action_loop/src/main.rs
+++ b/rust1.32/src/action_loop/src/main.rs
@@ -29,12 +29,12 @@ fn main() {
                     env::set_var(format!("__OW_{}", key.to_uppercase()), val.to_string());
                 }
                 match actionMain(input.value) {
-                    Ok(action_result) => {
-                        match serde_json::to_string(&action_result){
-                            Ok(response) =>  writeln!(&mut fd3, "{}", response).expect("Error writing on fd3"),
-                            Err(_) => writeln!(&mut fd3, "error").expect("Error writing on fd3"),
-                        } 
-                    }
+                    Ok(action_result) => match serde_json::to_string(&action_result) {
+                        Ok(response) => {
+                            writeln!(&mut fd3, "{}", response).expect("Error writing on fd3")
+                        }
+                        Err(_) => writeln!(&mut fd3, "error").expect("Error writing on fd3"),
+                    },
                     Err(err) => {
                         eprintln!("Error formatting result value json: {}", err);
                     }
@@ -48,4 +48,3 @@ fn main() {
         stderr().flush().expect("Error flushing stderr");
     }
 }
-

--- a/rust1.32/src/action_loop/src/main.rs
+++ b/rust1.32/src/action_loop/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
                         Ok(response) => {
                             writeln!(&mut fd3, "{}", response).expect("Error writing on fd3")
                         }
-                        Err(_) => writeln!(&mut fd3, r#"{"error":"Error parsing the action result"\n}"#).expect("Error writing on fd3"),
+                        Err(_) => writeln!(&mut fd3, "{{\"error\":\"Error parsing the action result\"\n}}").expect("Error writing on fd3"),
                     },
                     Err(err) => {
                         eprintln!("Error formatting result value json: {}", err);

--- a/rust1.32/src/action_loop/src/main.rs
+++ b/rust1.32/src/action_loop/src/main.rs
@@ -12,7 +12,7 @@ use std::{
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 struct Input {
-    value: HashMap<String, Value>,
+    value: Value,
     #[serde(flatten)]
     environment: HashMap<String, Value>,
 }
@@ -28,9 +28,12 @@ fn main() {
                 for (key, val) in input.environment {
                     env::set_var(format!("__OW_{}", key.to_uppercase()), val.to_string());
                 }
-                match serde_json::to_string(&actionMain(input.value)) {
-                    Ok(result) => {
-                        writeln!(&mut fd3, "{}", result).expect("Error writing on fd3");
+                match actionMain(input.value) {
+                    Ok(action_result) => {
+                        match serde_json::to_string(&action_result){
+                            Ok(response) =>  writeln!(&mut fd3, "{}", response).expect("Error writing on fd3"),
+                            Err(_) => writeln!(&mut fd3, "error").expect("Error writing on fd3"),
+                        } 
                     }
                     Err(err) => {
                         eprintln!("Error formatting result value json: {}", err);
@@ -45,3 +48,4 @@ fn main() {
         stderr().flush().expect("Error flushing stderr");
     }
 }
+

--- a/rust1.32/src/action_loop/src/main.rs
+++ b/rust1.32/src/action_loop/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
                         Ok(response) => {
                             writeln!(&mut fd3, "{}", response).expect("Error writing on fd3")
                         }
-                        Err(_) => writeln!(&mut fd3, "error").expect("Error writing on fd3"),
+                        Err(_) => writeln!(&mut fd3, r#"{"error":"Error parsing the action result"\n}"#).expect("Error writing on fd3"),
                     },
                     Err(err) => {
                         eprintln!("Error formatting result value json: {}", err);

--- a/rust1.32/src/actions/Cargo.toml
+++ b/rust1.32/src/actions/Cargo.toml
@@ -2,7 +2,11 @@
 name = "actions"
 version = "0.1.0"
 authors = ["Roberto Diaz <roberto@theagilemonkeys.com>"]
+edition = "2018"
 
 [dependencies]
 serde_json = "1.0"
+serde = "1.0"
+serde_derive = "1.0"
+
 

--- a/rust1.32/src/actions/src/lib.rs
+++ b/rust1.32/src/actions/src/lib.rs
@@ -1,10 +1,28 @@
 extern crate serde_json;
 
-use std::collections::HashMap;
-use serde_json::Value;
+use serde_derive::{Deserialize, Serialize};
+use serde_json::{Error, Value};
 
-
-pub fn main(mut input_data: HashMap<String, Value>) -> HashMap<String, Value> {
-    input_data.insert("added_key".to_string(),Value::String("test".to_string()));
-    input_data
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Input {
+    #[serde(default = "stranger")]
+    name: String,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Output {
+    greeting: String,
+}
+
+fn stranger() -> String {
+    "stranger".to_string()
+}
+
+pub fn main(args: Value) -> Result<Value, Error> {
+    let input: Input = serde_json::from_value(args)?;
+    let output = Output {
+        greeting: format!("Hello, {}", input.name),
+    };
+    serde_json::to_value(output)
+}
+

--- a/rust1.32/src/actions/src/lib.rs
+++ b/rust1.32/src/actions/src/lib.rs
@@ -25,4 +25,3 @@ pub fn main(args: Value) -> Result<Value, Error> {
     };
     serde_json::to_value(output)
 }
-


### PR DESCRIPTION
This PR includes the following changes:
* Changed the main function method signature from `main(Hashmap<String,Value>) -> HashMap<String,Value>` to `main(Value) -> Result<Value,Error>`. This change will allow the user to  map the input `Value` into a Rust object using the power of Serde library.
* Modified the example function to support this new method signature.
* Refactor in errors log, now all errors are printed into stderr and in fd3 they are dispatcher as `{"error":"error message"}`