### PR TITLE
Update Dockerfile build from source stanza.

### DIFF
--- a/core/rust1.34/Dockerfile
+++ b/core/rust1.34/Dockerfile
@@ -17,7 +17,12 @@
 
 # build go proxy from source
 FROM golang:1.15 AS builder_source
-RUN env CGO_ENABLED=0 go get github.com/apache/openwhisk-runtime-go/main && mv /go/bin/main /bin/proxy
+ARG GO_PROXY_GITHUB_USER=apache
+ARG GO_PROXY_GITHUB_BRANCH=master
+RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
+   https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
+   cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
+   mv proxy /bin/proxy
 
 # or build it from a release
 FROM golang:1.15 AS builder_release


### PR DESCRIPTION
This follows the pattern used in other repos to allow builds to select where to build source from.